### PR TITLE
Extra configuration options for text fields

### DIFF
--- a/lib/motion-settings-bundle/configuration.rb
+++ b/lib/motion-settings-bundle/configuration.rb
@@ -10,10 +10,10 @@ module Motion
 
       def text(title, options = {})
         preference(title, "PSTextFieldSpecifier", options, {
-          "IsSecure"               => false,
-          "KeyboardType"           => "Alphabet",
-          "AutocapitalizationType" => "Sentences",
-          "AutocorrectionType"     => "Default"
+          "IsSecure"               => options[:secure]             || false,
+          "KeyboardType"           => options[:keyboard]           || "Alphabet",
+          "AutocapitalizationType" => options[:autocapitalization] || "Sentences",
+          "AutocorrectionType"     => options[:autocorrection]     || "Default"
         })
       end
 

--- a/lib/motion-settings-bundle/configuration.rb
+++ b/lib/motion-settings-bundle/configuration.rb
@@ -12,7 +12,7 @@ module Motion
         preference(title, "PSTextFieldSpecifier", options, {
           "IsSecure"               => false,
           "KeyboardType"           => "Alphabet",
-          "AutoCapitalizationType" => "Sentences",
+          "AutocapitalizationType" => "Sentences",
           "AutocorrectionType"     => "Default"
         })
       end


### PR DESCRIPTION
Hi Nick,

I am not an iOS developer but I created a new Root.plist file with the latest Xcode and checked the `AutocapitalizationType` setting. It looks like the _C_ in _capitalization_ is not capitalized, oh, irony. So, here you go, first minor change.

Secondly I added a `secure`, `keyboard`, `autocapitalization` and `autocorrection` option. All options default to the values you specified earlier. This should make the field configuration somewhat more flexible.

I needed a secure password field and prefer the _EmailAddress_ keyboard for my e-mail field. You can now add those options when defining text fields:

```
bundle.text "E-mail", key: "email", keyboard: "EmailAddress", autocapitalization: "None"
bundle.text "Password", key: "password", secure: true
```
