### PR TITLE
update dependency

### DIFF
--- a/motion-settings-bundle.gemspec
+++ b/motion-settings-bundle.gemspec
@@ -15,6 +15,6 @@ Gem::Specification.new do |gem|
   gem.require_paths = ["lib"]
   gem.version       = Motion::SettingsBundle::VERSION
 
-  gem.add_dependency 'plist', '>= 3.1.0'
+  gem.add_dependency 'plist', '~> 3.1'
   gem.add_development_dependency 'rake'
 end

--- a/motion-settings-bundle.gemspec
+++ b/motion-settings-bundle.gemspec
@@ -15,6 +15,6 @@ Gem::Specification.new do |gem|
   gem.require_paths = ["lib"]
   gem.version       = Motion::SettingsBundle::VERSION
 
-  gem.add_dependency 'plist', '~> 3.1.0'
+  gem.add_dependency 'plist', '>= 3.1.0'
   gem.add_development_dependency 'rake'
 end


### PR DESCRIPTION
`plist` version 3.1.0 cause motion-provisioning to fail, and conflict with fastlane, ruby-xcdm (they are all compatible with plist-3.3.0).